### PR TITLE
Remove links to definitions and examples in DAK

### DIFF
--- a/input/pagecontent/downloads.md
+++ b/input/pagecontent/downloads.md
@@ -6,23 +6,3 @@ This is the technical package containing the artifacts in this Implementation Gu
 
 * [IG Package](package.tgz)
 
-### Definitions
-
-In addition to the above, we have provided format-specific _definitions_:
-
-* [XML](definitions.xml.zip)
-* [JSON](definitions.json.zip)
-* [TTL](definitions.ttl.zip)
-
-    These files should be the first choice whenever generating any implementation artifacts since they contain all of the rules about what makes these profiles valid.
-    Implementers will still need to be familiar with the content of the specification and profiles that apply in order to make a conformant implementation.
-    See the overview on [validating FHIR profiles and resources](http://hl7.org/fhir/validation.html) for more information about validating profiles and how to use these artifacts.
-
-
-### Examples
-
-    All examples used in this Implementation Guide:
-
-* [XML](examples.xml.zip)
-* [JSON](examples.json.zip)
-* [TTL](examples.ttl.zip)


### PR DESCRIPTION
(could not create an issue but this PR may be sufficient)